### PR TITLE
EventHandlerProperty to simplify definition of actions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,6 +16,9 @@ script:
 os:
   - linux
   - osx
-osx_image: xcode9.3
 env:
   - TEST_SUITE=.
+matrix:
+  exclude:
+    - jdk: oraclejdk8
+      os: osx

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,5 +16,6 @@ script:
 os:
   - linux
   - osx
+osx_image: xcode9.3
 env:
   - TEST_SUITE=.

--- a/beaninfo-api/pom.xml
+++ b/beaninfo-api/pom.xml
@@ -129,6 +129,7 @@
                   </docletArtifact>
                   <additionalOptions>
                       <additionalparam>-snippetpath ../beaninfo-embedded/src/main/</additionalparam>
+                      <additionalparam>-snippetpath ../beaninfo-testing/app/src/main/</additionalparam>
                       <additionalparam>-hiddingannotation java.lang.Deprecated</additionalparam>
                   </additionalOptions>
               </configuration>

--- a/beaninfo-api/pom.xml
+++ b/beaninfo-api/pom.xml
@@ -171,6 +171,21 @@
                   <tag>release-${releaseVersion}</tag>
               </configuration>
           </plugin>
+          <plugin>
+              <groupId>org.netbeans.tools</groupId>
+              <artifactId>sigtest-maven-plugin</artifactId>
+              <version>1.1</version>
+              <executions>
+                  <execution>
+                      <goals>
+                          <goal>generate</goal>
+                      </goals>
+                  </execution>
+              </executions>
+              <configuration>
+                  <packages>com.dukescript.api.javafx.beans,com.dukescript.spi.javafx.beans</packages>
+              </configuration>
+          </plugin>
       </plugins>
   </build>
   <dependencies>

--- a/beaninfo-api/pom.xml
+++ b/beaninfo-api/pom.xml
@@ -118,9 +118,12 @@
               <version>3.0.1</version>
               <configuration>
                   <subpackages>com.dukescript.api.javafx.beans</subpackages>
-                  <links>
-                      <link>https://docs.oracle.com/javase/8/javafx/api/</link>
-                  </links>
+                  <offlineLinks>
+                      <offlineLink>
+                          <url>https://docs.oracle.com/javase/8/javafx/api/</url>
+                          <location>https://docs.oracle.com/javase/8/javafx/api/</location>
+                      </offlineLink>
+                  </offlineLinks>
                   <doclet>org.apidesign.javadoc.codesnippet.Doclet</doclet>
                   <docletArtifact>
                       <groupId>org.apidesign.javadoc</groupId>

--- a/beaninfo-api/pom.xml
+++ b/beaninfo-api/pom.xml
@@ -131,6 +131,7 @@
                       <version>0.30</version>
                   </docletArtifact>
                   <additionalOptions>
+                      <additionalparam>-snippetpath src/test/</additionalparam>
                       <additionalparam>-snippetpath ../beaninfo-embedded/src/main/</additionalparam>
                       <additionalparam>-snippetpath ../beaninfo-testing/app/src/main/</additionalparam>
                       <additionalparam>-hiddingannotation java.lang.Deprecated</additionalparam>

--- a/beaninfo-api/src/main/java/com/dukescript/api/javafx/beans/ActionDataEvent.java
+++ b/beaninfo-api/src/main/java/com/dukescript/api/javafx/beans/ActionDataEvent.java
@@ -45,16 +45,22 @@ import net.java.html.json.Models;
  * is needed.
  */
 public final class ActionDataEvent extends ActionEvent {
-    private static final ActionDataEventFactory FACTORY = new ActionDataEventFactory() {
-        @Override
-        public ActionDataEvent create(ActionDataEventFactory.Convertor owner, FXBeanInfo.Provider model, Object source, Object event) {
-            return new ActionDataEvent(owner, model, source, source);
-        }
-    };
+    private static final Creator FACTORY = new Creator();
 
     private final FXBeanInfo.Provider model;
     private final ActionDataEventFactory.Convertor conv;
     private final Object event;
+
+    /** Constructs new ActionDataEvent.
+     *
+     * @param model provider of the {@link FXBeanInfo}
+     * @param source source of the event, possibly same as {@code model}
+     * @param event the event object to deliver
+     * @since 0.4
+     */
+    public ActionDataEvent(FXBeanInfo.Provider model, Object source, Object event) {
+        this(null, model, source, event);
+    }
 
     ActionDataEvent(ActionDataEventFactory.Convertor conv, FXBeanInfo.Provider model, Object source, Object event) {
         super(source, null);
@@ -73,9 +79,9 @@ public final class ActionDataEvent extends ActionEvent {
     public <T> T getProperty(Class<T> as, String name) {
         Object value;
         if (as == String.class) {
-            value = conv.toString(model.getFXBeanInfo(), event, name);
+            value = conv().toString(model.getFXBeanInfo(), event, name);
         } else if (Number.class.isAssignableFrom(as)) {
-            value = conv.toNumber(model.getFXBeanInfo(), event, name);
+            value = conv().toNumber(model.getFXBeanInfo(), event, name);
         } else {
             value = null;
         }
@@ -96,10 +102,25 @@ public final class ActionDataEvent extends ActionEvent {
     private <T> T extractValue(Class<T> as, Object d) {
         Object obj;
         if (Models.isModel(as)) {
-            obj = conv.toModel(model.getFXBeanInfo(), as, d);
+            obj = conv().toModel(model.getFXBeanInfo(), as, d);
         } else {
             obj = d;
         }
-        return conv.extractValue(as, obj);
+        return conv().extractValue(as, obj);
+    }
+
+    private ActionDataEventFactory.Convertor conv() {
+        return conv != null ? conv : FACTORY.none0();
+    }
+
+    private static class Creator extends ActionDataEventFactory {
+        @Override
+        public ActionDataEvent create(ActionDataEventFactory.Convertor owner, FXBeanInfo.Provider model, Object source, Object event) {
+            return new ActionDataEvent(owner, model, source, source);
+        }
+
+        public ActionDataEventFactory.Convertor none0() {
+            return none();
+        }
     }
 }

--- a/beaninfo-api/src/main/java/com/dukescript/api/javafx/beans/ActionDataEvent.java
+++ b/beaninfo-api/src/main/java/com/dukescript/api/javafx/beans/ActionDataEvent.java
@@ -33,7 +33,7 @@ import net.java.html.json.Models;
 
 /** Enhanced version of {@link ActionEvent}. Actions that can be invoked
  * on a {@linkplain FXBeanInfo#getBean() bean} are
- * {@linkplain FXBeanInfo#getFunctions() represented as properties}
+ * {@linkplain FXBeanInfo#getActions() () represented as event handler properties}
  * with {@link EventHandler} that accepts {@link ActionEvent} or its
  * {@link ActionDataEvent} subclass.
  * <p>
@@ -51,7 +51,10 @@ public final class ActionDataEvent extends ActionEvent {
     private final ActionDataEventFactory.Convertor conv;
     private final Object event;
 
-    /** Constructs new ActionDataEvent.
+    /** Constructs new event. Useful for invoking actions provided by 
+     * JavaFX beans:
+     * <p>
+     * {@codesnippet com.dukescript.javafx.tests.BeanInfoCheck#invokeEventHandlerProperty}
      *
      * @param model provider of the {@link FXBeanInfo}
      * @param source source of the event, possibly same as {@code model}

--- a/beaninfo-api/src/main/java/com/dukescript/api/javafx/beans/DelegateEventHandlerProperty.java
+++ b/beaninfo-api/src/main/java/com/dukescript/api/javafx/beans/DelegateEventHandlerProperty.java
@@ -1,4 +1,4 @@
-package com.dukescript.javafx.tests;
+package com.dukescript.api.javafx.beans;
 
 /*-
  * #%L
@@ -12,10 +12,10 @@ package com.dukescript.javafx.tests;
  * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
  * copies of the Software, and to permit persons to whom the Software is
  * furnished to do so, subject to the following conditions:
- * 
+ *
  * The above copyright notice and this permission notice shall be included in
  * all copies or substantial portions of the Software.
- * 
+ *
  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
  * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
  * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -26,42 +26,48 @@ package com.dukescript.javafx.tests;
  * #L%
  */
 
+import javafx.beans.InvalidationListener;
+import javafx.beans.property.ReadOnlyProperty;
+import javafx.beans.value.ChangeListener;
+import javafx.event.EventHandler;
 
-import com.dukescript.api.javafx.beans.EventHandlerProperty;
-import com.dukescript.api.javafx.beans.FXBeanInfo;
-import java.util.Map;
-import javafx.event.ActionEvent;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import org.junit.Test;
+final class DelegateEventHandlerProperty implements EventHandlerProperty {
 
-public class BeanInfoCheck {
-    private int count;
+    private final ReadOnlyProperty<? extends EventHandler<? super ActionDataEvent>> p;
 
-    @Test
-    public void beanInfoCanBeCreated() {
-        FXBeanInfo info = FXBeanInfo.newBuilder(this).build();
-        assertNotNull("Bean info created", info);
+    DelegateEventHandlerProperty(ReadOnlyProperty<? extends EventHandler<? super ActionDataEvent>> p) {
+        this.p = p;
     }
 
-    private void handleAction(ActionEvent ev) {
-        count++;
+    @Override
+    public Object getBean() {
+        return p.getBean();
     }
 
-    @Test
-    public void beanInfoCanHaveActions() {
-        FXBeanInfo info = FXBeanInfo.newBuilder(this)
-                .action("myAction", this::handleAction)
-                .build();
-
-        assertNotNull("Bean info created", info);
-        assertEquals("One action found", 1, info.getActions().size());
-        Map.Entry<String, EventHandlerProperty> registeredAction =
-                info.getActions().entrySet().iterator().next();
-
-        assertEquals("myAction", registeredAction.getKey());
-
-        registeredAction.getValue().getValue().handle(null);
-        assertEquals("Action was called", 1, count);
+    @Override
+    public String getName() {
+        return p.getName();
     }
+
+    @Override
+    public void addListener(ChangeListener<? super EventHandler<? super ActionDataEvent>> cl) {
+    }
+
+    @Override
+    public void removeListener(ChangeListener<? super EventHandler<? super ActionDataEvent>> cl) {
+    }
+
+    @Override
+    public EventHandler<? super ActionDataEvent> getValue() {
+        return p.getValue();
+    }
+
+    @Override
+    public void addListener(InvalidationListener il) {
+    }
+
+    @Override
+    public void removeListener(InvalidationListener il) {
+    }
+
 }

--- a/beaninfo-api/src/main/java/com/dukescript/api/javafx/beans/EventHandlerProperty.java
+++ b/beaninfo-api/src/main/java/com/dukescript/api/javafx/beans/EventHandlerProperty.java
@@ -34,8 +34,8 @@ import javafx.event.EventHandler;
  * {@link FXBeanInfo.Builder#action} methods to create instance of the 
  * property rather than implementing the interface manually.
  * <p>
- * The following example defines a class with three action methods
- * the uses their handle references to register them into the builder:
+ * The following example defines a class with three action methods and
+ * then uses their handle references to register them into the builder:
  * <p>
  * {@codesnippet com.dukescript.javafx.tests.BeanInfoCheck#CountingBean}
  * <p>

--- a/beaninfo-api/src/main/java/com/dukescript/api/javafx/beans/EventHandlerProperty.java
+++ b/beaninfo-api/src/main/java/com/dukescript/api/javafx/beans/EventHandlerProperty.java
@@ -30,20 +30,21 @@ import javafx.beans.property.ReadOnlyProperty;
 import javafx.event.ActionEvent;
 import javafx.event.EventHandler;
 
-/** Property representing an {@link EventHandler}. It can be used
- * at the places where
- * n Enhanced version of {@link ActionEvent}. Actions that can be invoked
- * on a {@linkplain FXBeanInfo#getBean() bean} are
- * {@linkplain FXBeanInfo#getFunctions() represented as properties}
- * with  that accepts {@link ActionEvent} or its
- * {@link ActionDataEvent} subclass.
+/** Property representing an {@link EventHandler}. Use one of
+ * {@link FXBeanInfo.Builder#action} methods to create instance of the 
+ * property rather than implementing the interface manually.
  * <p>
- * Stick to {@link ActionEvent} if it provides enough information. Use
- * this subclass if additional
- * information about the
- * {@link #getProperty(java.lang.Class, java.lang.String) event properties}
- * or type-safe view of the {@link #getSource(java.lang.Class) event source}
- * is needed.
+ * The following example defines a class with three action methods
+ * the uses their handle references to register them into the builder:
+ * <p>
+ * {@codesnippet com.dukescript.javafx.tests.BeanInfoCheck#CountingBean}
+ * <p>
+ * The handler method may take no arguments, a single {@link ActionEvent} parameter
+ * or a single {@link ActionDataEvent} parameter.
+ * The registered methods are then accessible via {@link FXBeanInfo#getActions()}
+ * map.
+ * 
+ * @since 0.4
  */
 public interface EventHandlerProperty extends ReadOnlyProperty<EventHandler<? super ActionDataEvent>> {
 }

--- a/beaninfo-api/src/main/java/com/dukescript/api/javafx/beans/EventHandlerProperty.java
+++ b/beaninfo-api/src/main/java/com/dukescript/api/javafx/beans/EventHandlerProperty.java
@@ -1,4 +1,4 @@
-package com.dukescript.javafx.tests;
+package com.dukescript.api.javafx.beans;
 
 /*-
  * #%L
@@ -12,10 +12,10 @@ package com.dukescript.javafx.tests;
  * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
  * copies of the Software, and to permit persons to whom the Software is
  * furnished to do so, subject to the following conditions:
- * 
+ *
  * The above copyright notice and this permission notice shall be included in
  * all copies or substantial portions of the Software.
- * 
+ *
  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
  * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
  * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -26,42 +26,24 @@ package com.dukescript.javafx.tests;
  * #L%
  */
 
-
-import com.dukescript.api.javafx.beans.EventHandlerProperty;
-import com.dukescript.api.javafx.beans.FXBeanInfo;
-import java.util.Map;
+import javafx.beans.property.ReadOnlyProperty;
 import javafx.event.ActionEvent;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import org.junit.Test;
+import javafx.event.EventHandler;
 
-public class BeanInfoCheck {
-    private int count;
-
-    @Test
-    public void beanInfoCanBeCreated() {
-        FXBeanInfo info = FXBeanInfo.newBuilder(this).build();
-        assertNotNull("Bean info created", info);
-    }
-
-    private void handleAction(ActionEvent ev) {
-        count++;
-    }
-
-    @Test
-    public void beanInfoCanHaveActions() {
-        FXBeanInfo info = FXBeanInfo.newBuilder(this)
-                .action("myAction", this::handleAction)
-                .build();
-
-        assertNotNull("Bean info created", info);
-        assertEquals("One action found", 1, info.getActions().size());
-        Map.Entry<String, EventHandlerProperty> registeredAction =
-                info.getActions().entrySet().iterator().next();
-
-        assertEquals("myAction", registeredAction.getKey());
-
-        registeredAction.getValue().getValue().handle(null);
-        assertEquals("Action was called", 1, count);
-    }
+/** Property representing an {@link EventHandler}. It can be used
+ * at the places where
+ * n Enhanced version of {@link ActionEvent}. Actions that can be invoked
+ * on a {@linkplain FXBeanInfo#getBean() bean} are
+ * {@linkplain FXBeanInfo#getFunctions() represented as properties}
+ * with  that accepts {@link ActionEvent} or its
+ * {@link ActionDataEvent} subclass.
+ * <p>
+ * Stick to {@link ActionEvent} if it provides enough information. Use
+ * this subclass if additional
+ * information about the
+ * {@link #getProperty(java.lang.Class, java.lang.String) event properties}
+ * or type-safe view of the {@link #getSource(java.lang.Class) event source}
+ * is needed.
+ */
+public interface EventHandlerProperty extends ReadOnlyProperty<EventHandler<? super ActionDataEvent>> {
 }

--- a/beaninfo-api/src/main/java/com/dukescript/api/javafx/beans/EventHandlerProperty.java
+++ b/beaninfo-api/src/main/java/com/dukescript/api/javafx/beans/EventHandlerProperty.java
@@ -43,7 +43,12 @@ import javafx.event.EventHandler;
  * or a single {@link ActionDataEvent} parameter.
  * The registered methods are then accessible via {@link FXBeanInfo#getActions()}
  * map.
- * 
+ * <p>
+ * There is also a way to register the actions directly via properties.
+ * Here is an example:
+ * <p>
+ * {@codesnippet com.dukescript.api.javafx.beans.EventHandlerPropertyTest#CountingBean}
+ *
  * @since 0.4
  */
 public interface EventHandlerProperty extends ReadOnlyProperty<EventHandler<? super ActionDataEvent>> {

--- a/beaninfo-api/src/main/java/com/dukescript/api/javafx/beans/FXBeanInfo.java
+++ b/beaninfo-api/src/main/java/com/dukescript/api/javafx/beans/FXBeanInfo.java
@@ -35,6 +35,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.ServiceLoader;
+import javafx.beans.property.ObjectProperty;
 import javafx.beans.property.ReadOnlyProperty;
 import javafx.beans.value.ObservableValue;
 import javafx.event.ActionEvent;
@@ -262,12 +263,18 @@ public final class FXBeanInfo {
             return action(prop);
         }
 
-        /** Registers action property. Actions are defined as {@link EventHandlerProperty}
+        /** Generic way to register an action property.
+         * Actions are defined as {@link EventHandlerProperty}
          * instances. This method allows direct registration of such property. However,
          * rather than using this method directly, consider registering the
          * actions via method references:
          * <p>
          * {@codesnippet com.dukescript.javafx.tests.BeanInfoCheck#CountingBean}
+         * <p>
+         * In case manipulation with actual {@link ObjectProperty} is needed, here
+         * is an example showing a path through all the generic signatures:
+         * <p>
+         * {@codesnippet com.dukescript.api.javafx.beans.EventHandlerPropertyTest#actionProperty}
          *
          * @param p instance of {@link EventHandlerProperty} to register
          * @return {@code this} builder

--- a/beaninfo-api/src/main/java/com/dukescript/api/javafx/beans/FXBeanInfo.java
+++ b/beaninfo-api/src/main/java/com/dukescript/api/javafx/beans/FXBeanInfo.java
@@ -263,6 +263,21 @@ public final class FXBeanInfo {
             return action(prop);
         }
 
+        /** @deprecated to be removed, use {@link #action(com.dukescript.api.javafx.beans.EventHandlerProperty)}
+         * @deprecated
+         */
+        @Deprecated
+        public Builder action(ReadOnlyProperty<? extends EventHandler<? super ActionDataEvent>> p) {
+            System.err.println("this method will be removed: " + p);
+            EventHandlerProperty ehp;
+            if (p instanceof EventHandlerProperty) {
+                ehp = (EventHandlerProperty) p;
+            } else {
+                ehp = new DelegateEventHandlerProperty(p);
+            }
+            return action(ehp);
+        }
+
         /** Generic way to register an action property.
          * Actions are defined as {@link EventHandlerProperty}
          * instances. This method allows direct registration of such property. However,
@@ -274,18 +289,13 @@ public final class FXBeanInfo {
          * In case manipulation with actual {@link ObjectProperty} is needed, here
          * is an example showing a path through all the generic signatures:
          * <p>
-         * {@codesnippet com.dukescript.api.javafx.beans.EventHandlerPropertyTest#actionProperty}
+         * {@codesnippet com.dukescript.api.javafx.beans.EventHandlerPropertyTest#CountingBean}
          *
          * @param p instance of {@link EventHandlerProperty} to register
          * @return {@code this} builder
+         * @since 0.4
          */
-        public Builder action(ReadOnlyProperty<? extends EventHandler<? super ActionDataEvent>> p) {
-            EventHandlerProperty ehp;
-            if (p instanceof EventHandlerProperty) {
-                ehp = (EventHandlerProperty) p;
-            } else {
-                ehp = new DelegateEventHandlerProperty(p);
-            }
+        public Builder action(EventHandlerProperty p) {
             if (this.functions == null) {
                 this.functions = new LinkedHashMap<>();
             }
@@ -293,7 +303,7 @@ public final class FXBeanInfo {
             if (name == null) {
                 throw new NullPointerException("No name for " + p);
             }
-            EventHandlerProperty prev = this.functions.put(name, ehp);
+            EventHandlerProperty prev = this.functions.put(name, p);
             if (prev != null) {
                 this.functions.put(name, prev);
                 throw new IllegalArgumentException("Cannot redefine " + prev + " with " + p);

--- a/beaninfo-api/src/main/java/com/dukescript/api/javafx/beans/FXBeanInfo.java
+++ b/beaninfo-api/src/main/java/com/dukescript/api/javafx/beans/FXBeanInfo.java
@@ -102,10 +102,14 @@ public final class FXBeanInfo {
         return functions;
     }
 
-    /** Invocable handlers for {@linkplain #getBean() this bean}.
+    /** {@link EventHandler} properties for {@linkplain #getBean() this bean}.
+     * Use following code to invoke them:
+     * <p>
+     * {@codesnippet com.dukescript.javafx.tests.BeanInfoCheck#invokeEventHandlerProperty}
      *
      * @return immutable map of available {@link EventHandler event handlers}
-     * @since 0.3
+     * @since 0.4
+     * @see ActionDataEvent
      */
     public Map<String, EventHandlerProperty> getActions() {
         return functions;

--- a/beaninfo-api/src/main/java/com/dukescript/api/javafx/beans/SimpleEventHandlerProperty.java
+++ b/beaninfo-api/src/main/java/com/dukescript/api/javafx/beans/SimpleEventHandlerProperty.java
@@ -27,31 +27,13 @@ package com.dukescript.api.javafx.beans;
  */
 
 import javafx.beans.property.SimpleObjectProperty;
-import javafx.event.ActionEvent;
 import javafx.event.EventHandler;
 
-/** Property representing an {@link EventHandler}. It can be used
- * at the places where one wants to hold a handler for
- * {@link ActionDataEvent} or {@link ActionEvent}.
- */
-public class SimpleEventHandlerProperty extends
+final class SimpleEventHandlerProperty extends
     SimpleObjectProperty<EventHandler<? super ActionDataEvent>>
     implements EventHandlerProperty {
 
-    public SimpleEventHandlerProperty() {
-    }
-
-    public SimpleEventHandlerProperty(
-        EventHandler<? super ActionDataEvent> handler
-    ) {
-        super(handler);
-    }
-
-    public SimpleEventHandlerProperty(Object bean, String name) {
-        super(bean, name);
-    }
-
-    public SimpleEventHandlerProperty(
+    SimpleEventHandlerProperty(
         Object bean, String name, EventHandler<? super ActionDataEvent> handler
     ) {
         super(bean, name, handler);

--- a/beaninfo-api/src/main/java/com/dukescript/api/javafx/beans/SimpleEventHandlerProperty.java
+++ b/beaninfo-api/src/main/java/com/dukescript/api/javafx/beans/SimpleEventHandlerProperty.java
@@ -1,4 +1,4 @@
-package com.dukescript.javafx.tests;
+package com.dukescript.api.javafx.beans;
 
 /*-
  * #%L
@@ -12,10 +12,10 @@ package com.dukescript.javafx.tests;
  * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
  * copies of the Software, and to permit persons to whom the Software is
  * furnished to do so, subject to the following conditions:
- * 
+ *
  * The above copyright notice and this permission notice shall be included in
  * all copies or substantial portions of the Software.
- * 
+ *
  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
  * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
  * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -26,42 +26,34 @@ package com.dukescript.javafx.tests;
  * #L%
  */
 
-
-import com.dukescript.api.javafx.beans.EventHandlerProperty;
-import com.dukescript.api.javafx.beans.FXBeanInfo;
-import java.util.Map;
+import javafx.beans.property.SimpleObjectProperty;
 import javafx.event.ActionEvent;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import org.junit.Test;
+import javafx.event.EventHandler;
 
-public class BeanInfoCheck {
-    private int count;
+/** Property representing an {@link EventHandler}. It can be used
+ * at the places where one wants to hold a handler for
+ * {@link ActionDataEvent} or {@link ActionEvent}.
+ */
+public class SimpleEventHandlerProperty extends
+    SimpleObjectProperty<EventHandler<? super ActionDataEvent>>
+    implements EventHandlerProperty {
 
-    @Test
-    public void beanInfoCanBeCreated() {
-        FXBeanInfo info = FXBeanInfo.newBuilder(this).build();
-        assertNotNull("Bean info created", info);
+    public SimpleEventHandlerProperty() {
     }
 
-    private void handleAction(ActionEvent ev) {
-        count++;
+    public SimpleEventHandlerProperty(
+        EventHandler<? super ActionDataEvent> handler
+    ) {
+        super(handler);
     }
 
-    @Test
-    public void beanInfoCanHaveActions() {
-        FXBeanInfo info = FXBeanInfo.newBuilder(this)
-                .action("myAction", this::handleAction)
-                .build();
+    public SimpleEventHandlerProperty(Object bean, String name) {
+        super(bean, name);
+    }
 
-        assertNotNull("Bean info created", info);
-        assertEquals("One action found", 1, info.getActions().size());
-        Map.Entry<String, EventHandlerProperty> registeredAction =
-                info.getActions().entrySet().iterator().next();
-
-        assertEquals("myAction", registeredAction.getKey());
-
-        registeredAction.getValue().getValue().handle(null);
-        assertEquals("Action was called", 1, count);
+    public SimpleEventHandlerProperty(
+        Object bean, String name, EventHandler<? super ActionDataEvent> handler
+    ) {
+        super(bean, name, handler);
     }
 }

--- a/beaninfo-api/src/main/java/com/dukescript/api/javafx/beans/SimpleEventHandlerProperty.java
+++ b/beaninfo-api/src/main/java/com/dukescript/api/javafx/beans/SimpleEventHandlerProperty.java
@@ -29,11 +29,60 @@ package com.dukescript.api.javafx.beans;
 import javafx.beans.property.SimpleObjectProperty;
 import javafx.event.EventHandler;
 
-final class SimpleEventHandlerProperty extends
+/**
+ * Simple implementation of a property
+ * representing an {@link FXBeanInfo#getActions() action} in the
+ * {@link FXBeanInfo}.
+ * <p>
+ * It is usually easier to use
+ * {@link FXBeanInfo.Builder#action(java.lang.String, java.lang.Runnable)}
+ * or
+ * {@link FXBeanInfo.Builder#action(java.lang.String, javafx.event.EventHandler)},
+ * but should properties be the preferred way to represent actions,
+ * here is how to use them:
+ * <p>
+ * {@codesnippet com.dukescript.api.javafx.beans.EventHandlerPropertyTest#CountingBean}
+ *
+ * @since 0.4
+ */
+public class SimpleEventHandlerProperty extends
     SimpleObjectProperty<EventHandler<? super ActionDataEvent>>
     implements EventHandlerProperty {
 
-    SimpleEventHandlerProperty(
+    /** Default constructor.
+     * @since 0.4
+     */
+    public SimpleEventHandlerProperty() {
+        super();
+    }
+
+    /** Constructor with handler.
+     *
+     * @param handler provide the handler
+     * @since 0.4
+     */
+    public SimpleEventHandlerProperty(EventHandler<? super ActionDataEvent> handler) {
+        super(handler);
+    }
+
+    /** Constructor with bean and name.
+     *
+     * @param bean the bean
+     * @param name the name of the property
+     */
+    public SimpleEventHandlerProperty(Object bean, String name) {
+        super(bean, name);
+    }
+
+    /** Constructor with all attributes.
+     *
+     * @param bean the bean
+     * @param name name of the property
+     * @param handler handler
+     *
+     * @since 0.4
+     */
+    public SimpleEventHandlerProperty(
         Object bean, String name, EventHandler<? super ActionDataEvent> handler
     ) {
         super(bean, name, handler);

--- a/beaninfo-api/src/main/java/com/dukescript/impl/javafx/beans/ActionDataEventFactory.java
+++ b/beaninfo-api/src/main/java/com/dukescript/impl/javafx/beans/ActionDataEventFactory.java
@@ -38,9 +38,6 @@ public abstract class ActionDataEventFactory {
         } catch (ClassNotFoundException ex) {
             throw new IllegalStateException(ex);
         }
-        if (INSTANCE == null) {
-            throw new IllegalStateException();
-        }
     }
 
     protected ActionDataEventFactory() {
@@ -50,6 +47,10 @@ public abstract class ActionDataEventFactory {
         INSTANCE = this;
     }
     protected abstract ActionDataEvent create(Convertor owner, FXBeanInfo.Provider model, Object source, Object event);
+
+    protected final Convertor none() {
+        return NONE;
+    }
 
     public static ActionDataEvent newEvent(Convertor owner, FXBeanInfo.Provider model, Object source, Object event) {
         return INSTANCE.create(owner, model, source, event);
@@ -64,4 +65,25 @@ public abstract class ActionDataEventFactory {
 
         public <T> T extractValue(Class<T> as, Object obj);
     }
+    private static final Convertor NONE = new Convertor() {
+        @Override
+        public Object toString(FXBeanInfo fxBeanInfo, Object event, String name) {
+            return event.toString();
+        }
+
+        @Override
+        public Object toNumber(FXBeanInfo fxBeanInfo, Object event, String name) {
+            return event instanceof Number ? event : null;
+        }
+
+        @Override
+        public <T> Object toModel(FXBeanInfo fxBeanInfo, Class<T> as, Object obj) {
+            return as.isInstance(obj) ? as.cast(obj) : null;
+        }
+
+        @Override
+        public <T> T extractValue(Class<T> as, Object obj) {
+            return as.isInstance(obj) ? as.cast(obj) : null;
+        }
+    };
 }

--- a/beaninfo-api/src/main/java/com/dukescript/impl/javafx/beans/FXHtml4Java.java
+++ b/beaninfo-api/src/main/java/com/dukescript/impl/javafx/beans/FXHtml4Java.java
@@ -27,6 +27,7 @@ package com.dukescript.impl.javafx.beans;
  */
 
 import com.dukescript.api.javafx.beans.ActionDataEvent;
+import com.dukescript.api.javafx.beans.EventHandlerProperty;
 import com.dukescript.api.javafx.beans.FXBeanInfo;
 import java.util.Map;
 import javafx.beans.property.Property;
@@ -68,7 +69,7 @@ final class FXHtml4Java extends Proto.Type<FXBeanInfo.Provider> implements Actio
             registerProperty(name, index++, readOnly, constant);
         }
         index = 0;
-        for (Map.Entry<String, ReadOnlyProperty<? extends EventHandler<? super ActionDataEvent>>> e : info.getActions().entrySet()) {
+        for (Map.Entry<String, EventHandlerProperty> e : info.getActions().entrySet()) {
             String name = e.getKey();
             registerFunction(name, index++);
         }

--- a/beaninfo-api/src/test/java/com/dukescript/api/javafx/beans/EventHandlerPropertyTest.java
+++ b/beaninfo-api/src/test/java/com/dukescript/api/javafx/beans/EventHandlerPropertyTest.java
@@ -1,0 +1,112 @@
+package com.dukescript.api.javafx.beans;
+
+/*-
+ * #%L
+ * DukeScript JavaFX Extensions - a library from the "DukeScript" project.
+ * %%
+ * Copyright (C) 2018 Dukehoff GmbH
+ * %%
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ * #L%
+ */
+
+import javafx.beans.property.ReadOnlyProperty;
+import javafx.beans.property.SimpleObjectProperty;
+import javafx.event.ActionEvent;
+import javafx.event.Event;
+import javafx.event.EventHandler;
+import org.junit.Test;
+import static org.junit.Assert.*;
+import org.junit.Before;
+
+public class EventHandlerPropertyTest {
+    // BEGIN: com.dukescript.api.javafx.beans.EventHandlerPropertyTest#actionProperty
+    class CountingBean implements FXBeanInfo.Provider {
+        private int count;
+
+        final ReadOnlyProperty<EventHandler<Event>> incrementAction =
+        new SimpleObjectProperty<>(this, "actionWithoutParameters", (ev) -> {
+            count++;
+        });
+
+        final ReadOnlyProperty<EventHandler<ActionEvent>> addAction =
+        new SimpleObjectProperty<>(this, "actionWithEvent", (ev) -> {
+            count += ((Number) ev.getSource()).intValue();
+        });
+
+        final ReadOnlyProperty<EventHandler<ActionDataEvent>> addTwiceAction =
+        new SimpleObjectProperty<>(this, "actionWithData", (ev) -> {
+            count += ev.getSource(Number.class).intValue();
+            count += ev.getProperty(Number.class, "any").intValue();
+        });
+
+        private final FXBeanInfo info = FXBeanInfo.newBuilder(this)
+            .action(this.incrementAction)
+            .action(this.addAction)
+            .action(this.addTwiceAction)
+            .build();
+
+        @Override
+        public FXBeanInfo getFXBeanInfo() {
+            return info;
+        }
+    }
+    // END: com.dukescript.api.javafx.beans.EventHandlerPropertyTest#actionProperty
+
+    private CountingBean bean;
+    private FXBeanInfo info;
+
+    @Before
+    public void createCountingBean() {
+        bean = new CountingBean();
+        info = bean.getFXBeanInfo();
+    }
+
+    @Test
+    public void testIncrementByOne() {
+        EventHandlerProperty p = info.getActions().get("actionWithoutParameters");
+        assertNotNull("property found", p);
+        final EventHandler<? super ActionDataEvent> h = p.getValue();
+        assertNotNull("it has handler", h);
+        h.handle(null);
+        assertEquals(1, bean.count);
+    }
+
+    @Test
+    public void testIncrementByThis() {
+        EventHandlerProperty p = info.getActions().get("actionWithEvent");
+        assertNotNull("property found", p);
+        final EventHandler<? super ActionDataEvent> h = p.getValue();
+        assertNotNull("it has handler", h);
+        ActionDataEvent ev = new ActionDataEvent(bean, 3, null);
+        h.handle(ev);
+        assertEquals(3, bean.count);
+    }
+
+    @Test
+    public void testIncrementByEvent() {
+        EventHandlerProperty p = info.getActions().get("actionWithData");
+        assertNotNull("property found", p);
+        final EventHandler<? super ActionDataEvent> h = p.getValue();
+        assertNotNull("it has handler", h);
+        ActionDataEvent ev = new ActionDataEvent(bean, 3, 5);
+        h.handle(ev);
+        assertEquals(8, bean.count);
+    }
+}

--- a/beaninfo-api/src/test/java/com/dukescript/api/javafx/beans/EventHandlerTest.java
+++ b/beaninfo-api/src/test/java/com/dukescript/api/javafx/beans/EventHandlerTest.java
@@ -28,7 +28,6 @@ package com.dukescript.api.javafx.beans;
 
 import javafx.event.ActionEvent;
 import javafx.event.EventHandler;
-import javafx.fxml.FXML;
 import org.junit.Before;
 import org.junit.Test;
 import static org.junit.Assert.*;
@@ -37,12 +36,12 @@ public class EventHandlerTest implements FXBeanInfo.Provider {
     private int count;
     private FXBeanInfo info;
 
-    @FXML
+    // @FXML
     public void incrementByOne() {
         count++;
     }
 
-    @FXML
+    // @FXML
     public void incrementByThis(ActionEvent ev) {
         if (ev == null) {
             count = -1;
@@ -52,7 +51,7 @@ public class EventHandlerTest implements FXBeanInfo.Provider {
         count += n.intValue();
     }
 
-    @FXML
+    // @FXML
     public void incrementByThisAndEvent(ActionDataEvent ev) {
         if (ev == null) {
             count = -1;

--- a/beaninfo-api/src/test/java/com/dukescript/api/javafx/beans/EventHandlerTest.java
+++ b/beaninfo-api/src/test/java/com/dukescript/api/javafx/beans/EventHandlerTest.java
@@ -52,11 +52,25 @@ public class EventHandlerTest implements FXBeanInfo.Provider {
         count += n.intValue();
     }
 
+    @FXML
+    public void incrementByThisAndEvent(ActionDataEvent ev) {
+        if (ev == null) {
+            count = -1;
+            return;
+        }
+        Number n = ev.getSource(Number.class);
+        count += n.intValue();
+
+        n = ev.getProperty(Number.class, null);
+        count += n.intValue();
+    }
+
     @Before
     public void generateInfo() {
         info = FXBeanInfo.newBuilder(this)
             .action("incrementByOne", this::incrementByOne)
             .action("incrementByThis", this::incrementByThis)
+            .action("incrementByThisAndEvent", this::incrementByThisAndEvent)
             .build();
     }
 
@@ -78,6 +92,22 @@ public class EventHandlerTest implements FXBeanInfo.Provider {
         assertNotNull("it has handler", h);
         h.handle(null);
         assertEquals(-1, count);
+        ActionDataEvent ev = new ActionDataEvent(this, 3, null);
+        h.handle(ev);
+        assertEquals(2, count);
+    }
+
+    @Test
+    public void testIncrementByEvent() {
+        EventHandlerProperty p = info.getActions().get("incrementByThisAndEvent");
+        assertNotNull("property found", p);
+        final EventHandler<? super ActionDataEvent> h = p.getValue();
+        assertNotNull("it has handler", h);
+        h.handle(null);
+        assertEquals(-1, count);
+        ActionDataEvent ev = new ActionDataEvent(this, 3, 5);
+        h.handle(ev);
+        assertEquals(7, count);
     }
 
     @Override

--- a/beaninfo-api/src/test/java/com/dukescript/api/javafx/beans/EventHandlerTest.java
+++ b/beaninfo-api/src/test/java/com/dukescript/api/javafx/beans/EventHandlerTest.java
@@ -1,0 +1,87 @@
+package com.dukescript.api.javafx.beans;
+
+/*-
+ * #%L
+ * DukeScript JavaFX Extensions - a library from the "DukeScript" project.
+ * %%
+ * Copyright (C) 2018 Dukehoff GmbH
+ * %%
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ * #L%
+ */
+
+import javafx.event.ActionEvent;
+import javafx.event.EventHandler;
+import javafx.fxml.FXML;
+import org.junit.Before;
+import org.junit.Test;
+import static org.junit.Assert.*;
+
+public class EventHandlerTest implements FXBeanInfo.Provider {
+    private int count;
+    private FXBeanInfo info;
+
+    @FXML
+    public void incrementByOne() {
+        count++;
+    }
+
+    @FXML
+    public void incrementByThis(ActionEvent ev) {
+        if (ev == null) {
+            count = -1;
+            return;
+        }
+        Number n = (Number) ev.getSource();
+        count += n.intValue();
+    }
+
+    @Before
+    public void generateInfo() {
+        info = FXBeanInfo.newBuilder(this)
+            .action("incrementByOne", this::incrementByOne)
+            .action("incrementByThis", this::incrementByThis)
+            .build();
+    }
+
+    @Test
+    public void testIncrementByOne() {
+        EventHandlerProperty p = info.getActions().get("incrementByOne");
+        assertNotNull("property found", p);
+        final EventHandler<? super ActionDataEvent> h = p.getValue();
+        assertNotNull("it has handler", h);
+        h.handle(null);
+        assertEquals(1, count);
+    }
+
+    @Test
+    public void testIncrementByThis() {
+        EventHandlerProperty p = info.getActions().get("incrementByThis");
+        assertNotNull("property found", p);
+        final EventHandler<? super ActionDataEvent> h = p.getValue();
+        assertNotNull("it has handler", h);
+        h.handle(null);
+        assertEquals(-1, count);
+    }
+
+    @Override
+    public FXBeanInfo getFXBeanInfo() {
+        return info;
+    }
+}

--- a/beaninfo-api/src/test/java/com/dukescript/api/javafx/beans/SimpleEventHandlerPropertyTest.java
+++ b/beaninfo-api/src/test/java/com/dukescript/api/javafx/beans/SimpleEventHandlerPropertyTest.java
@@ -26,32 +26,28 @@ package com.dukescript.api.javafx.beans;
  * #L%
  */
 
-import javafx.beans.property.ReadOnlyProperty;
-import javafx.beans.property.SimpleObjectProperty;
-import javafx.event.ActionEvent;
-import javafx.event.Event;
 import javafx.event.EventHandler;
 import org.junit.Test;
 import static org.junit.Assert.*;
 import org.junit.Before;
 
-public class EventHandlerPropertyTest {
-    // BEGIN: com.dukescript.api.javafx.beans.EventHandlerPropertyTest#actionProperty
+public class SimpleEventHandlerPropertyTest {
+    // BEGIN: com.dukescript.api.javafx.beans.EventHandlerPropertyTest#CountingBean
     class CountingBean implements FXBeanInfo.Provider {
         private int count;
 
-        final ReadOnlyProperty<EventHandler<Event>> incrementAction =
-        new SimpleObjectProperty<>(this, "actionWithoutParameters", (ev) -> {
+        final EventHandlerProperty incrementAction =
+        new SimpleEventHandlerProperty(this, "actionWithoutParameters", (ev) -> {
             count++;
         });
 
-        final ReadOnlyProperty<EventHandler<ActionEvent>> addAction =
-        new SimpleObjectProperty<>(this, "actionWithEvent", (ev) -> {
+        final EventHandlerProperty addAction =
+        new SimpleEventHandlerProperty(this, "actionWithEvent", (ev) -> {
             count += ((Number) ev.getSource()).intValue();
         });
 
-        final ReadOnlyProperty<EventHandler<ActionDataEvent>> addTwiceAction =
-        new SimpleObjectProperty<>(this, "actionWithData", (ev) -> {
+        final EventHandlerProperty addTwiceAction =
+        new SimpleEventHandlerProperty(this, "actionWithData", (ev) -> {
             count += ev.getSource(Number.class).intValue();
             count += ev.getProperty(Number.class, "any").intValue();
         });
@@ -67,7 +63,7 @@ public class EventHandlerPropertyTest {
             return info;
         }
     }
-    // END: com.dukescript.api.javafx.beans.EventHandlerPropertyTest#actionProperty
+    // END: com.dukescript.api.javafx.beans.EventHandlerPropertyTest#CountingBean
 
     private CountingBean bean;
     private FXBeanInfo info;

--- a/beaninfo-embedded/pom.xml
+++ b/beaninfo-embedded/pom.xml
@@ -37,7 +37,7 @@
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <mainClass>com.dukescript.javafx.fxbeaninfo.MainApp</mainClass>
+        <mainClass>com.dukescript.javafx.fxbeaninfo.Main</mainClass>
         <net.java.html.version>1.5.1</net.java.html.version>
     </properties>
 

--- a/beaninfo-embedded/pom.xml
+++ b/beaninfo-embedded/pom.xml
@@ -116,7 +116,7 @@
             <groupId>org.netbeans.html</groupId>
             <artifactId>net.java.html.boot.fx</artifactId>
             <version>${net.java.html.version}</version>
-            <scope>provided</scope>
+            <scope>compile</scope>
         </dependency>
         <dependency>
             <groupId>org.openjfx</groupId>

--- a/beaninfo-embedded/src/main/java/com/dukescript/javafx/fxbeaninfo/Main.java
+++ b/beaninfo-embedded/src/main/java/com/dukescript/javafx/fxbeaninfo/Main.java
@@ -25,32 +25,11 @@ package com.dukescript.javafx.fxbeaninfo;
  * THE SOFTWARE.
  * #L%
  */
-
-import com.dukescript.api.javafx.beans.FXBeanInfo;
-import javafx.beans.property.SimpleStringProperty;
-import javafx.beans.property.StringProperty;
-import javafx.event.ActionEvent;
-import javafx.fxml.FXML;
-
-// BEGIN: com.dukescript.javafx.fxbeaninfo.HTMLController
-public class HTMLController implements FXBeanInfo.Provider {
-    private final StringProperty labelText =
-            new SimpleStringProperty(this, "labelText", "");
-    
-    private void handleButtonAction(ActionEvent event) {
-        System.out.println("You clicked me!");
-        labelText.set("Hello World!");
+public final class Main {
+    private Main() {
     }
-
-    private final FXBeanInfo info = FXBeanInfo
-            .newBuilder(this)
-            .action("action", this::handleButtonAction)
-            .property(labelText)
-            .build();
     
-    @Override
-    public FXBeanInfo getFXBeanInfo() {
-        return info;
+    public static void main(String... args) {
+        MainApp.launch(MainApp.class, args);
     }
 }
-// END: com.dukescript.javafx.fxbeaninfo.HTMLController

--- a/beaninfo-embedded/src/main/java/com/dukescript/javafx/fxbeaninfo/MainApp.java
+++ b/beaninfo-embedded/src/main/java/com/dukescript/javafx/fxbeaninfo/MainApp.java
@@ -60,8 +60,4 @@ public class MainApp extends Application {
         stage.setScene(scene);
         stage.show();
     }
-
-    public static void main(String[] args) {
-        launch(args);
-    }
 }

--- a/beaninfo-testing/android/pom.xml
+++ b/beaninfo-testing/android/pom.xml
@@ -140,6 +140,7 @@
                         <!--<package>your.package.name</package> -->
                         <!--</packages> -->
                     </test>
+                    <testFailSafe>false</testFailSafe>
                     <assetsDirectory>src/main/webapp</assetsDirectory>
                     <apkDebug>${debug}</apkDebug>
                     <resourceDirectory>target/res</resourceDirectory>

--- a/beaninfo-testing/android/pom.xml
+++ b/beaninfo-testing/android/pom.xml
@@ -76,6 +76,7 @@
                 <version>2.9</version>
                 <executions>
                     <execution>
+                        <id>unpackage-deps</id>
                         <phase>process-classes</phase>
                         <goals>
                             <goal>unpack-dependencies</goal>
@@ -84,6 +85,42 @@
                             <includeScope>runtime</includeScope>
                             <outputDirectory>${project.build.directory}/classes</outputDirectory>
                         </configuration>
+                    </execution>
+                    <execution>
+                        <id>dalvik-sdk</id>
+                        <phase>validate</phase>
+                        <goals>
+                            <goal>unpack-dependencies</goal>
+                        </goals>
+                        <configuration>
+                            <includeArtifactIds>dalvik-sdk</includeArtifactIds>
+                            <includeScope>runtime</includeScope>
+                            <outputDirectory>${project.build.directory}/zips</outputDirectory>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-antrun-plugin</artifactId>
+                <version>1.8</version>
+                <executions>
+                    <execution>
+                        <id>dalvik-sdk</id>
+                        <phase>process-classes</phase>
+                        <configuration>
+                            <tasks>
+                                <unzip src="${basedir}/target/zips/dalvik-sdk/rt/lib/ext/jfxrt.jar" dest="${basedir}/target/classes/">
+                                    <patternset>
+                                       <include name="javafx/beans/**"/>
+                                       <include name="javafx/event/**"/>
+                                    </patternset>
+                                    </unzip>
+                            </tasks>
+                        </configuration>
+                        <goals>
+                            <goal>run</goal>
+                        </goals>
                     </execution>
                 </executions>
             </plugin>
@@ -188,6 +225,12 @@
             <artifactId>android</artifactId>
             <version>${platform.version}</version>
             <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.javafxports</groupId>
+            <artifactId>dalvik-sdk</artifactId>
+            <version>8.60.11</version>
+            <type>zip</type>
         </dependency>
         <dependency>
             <groupId>com.google.android</groupId>

--- a/beaninfo-testing/app/pom.xml
+++ b/beaninfo-testing/app/pom.xml
@@ -11,10 +11,10 @@
   to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
   copies of the Software, and to permit persons to whom the Software is
   furnished to do so, subject to the following conditions:
-  
+
   The above copyright notice and this permission notice shall be included in
   all copies or substantial portions of the Software.
-  
+
   THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
   IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
   FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -93,7 +93,11 @@
             <groupId>com.dukescript.api</groupId>
             <artifactId>javafx.beaninfo</artifactId>
             <version>${project.version}</version>
-            <type>jar</type>
+        </dependency>
+        <dependency>
+            <groupId>org.netbeans.html</groupId>
+            <artifactId>net.java.html.json</artifactId>
+            <version>${net.java.html.version}</version>
         </dependency>
         <dependency>
             <groupId>com.dukescript.api</groupId>

--- a/beaninfo-testing/app/pom.xml
+++ b/beaninfo-testing/app/pom.xml
@@ -113,6 +113,12 @@
         </dependency>
         <dependency>
             <groupId>org.openjfx</groupId>
+            <artifactId>javafx-base</artifactId>
+            <version>11</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.openjfx</groupId>
             <artifactId>javafx-web</artifactId>
             <version>11</version>
             <scope>test</scope>

--- a/beaninfo-testing/app/src/main/java/com/dukescript/javafx/tests/BeanInfoCheck.java
+++ b/beaninfo-testing/app/src/main/java/com/dukescript/javafx/tests/BeanInfoCheck.java
@@ -32,6 +32,7 @@ import com.dukescript.api.javafx.beans.EventHandlerProperty;
 import com.dukescript.api.javafx.beans.FXBeanInfo;
 import java.util.Map;
 import javafx.event.ActionEvent;
+import javafx.event.EventHandler;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import org.junit.Test;
@@ -98,9 +99,17 @@ public class BeanInfoCheck {
         EventHandlerProperty addSource = actions.get("actionWithEvent");
         addSource.getValue().handle(new ActionDataEvent(bean, 4, null));
         assertEquals("Action was called", 5, bean.count);
-
-        EventHandlerProperty addData = actions.get("actionWithData");
-        addData.getValue().handle(new ActionDataEvent(bean, 7, 13));
+        dispatchEvent(bean, "actionWithData");
         assertEquals("Action was called", 25, bean.count);
     }
+
+    // BEGIN: com.dukescript.javafx.tests.BeanInfoCheck#invokeEventHandlerProperty
+    private static void dispatchEvent(FXBeanInfo.Provider bean, String name) {
+        final FXBeanInfo info = bean.getFXBeanInfo();
+        final Map<String, EventHandlerProperty> actions = info.getActions();
+        EventHandlerProperty property = actions.get(name);
+        final EventHandler<? super ActionDataEvent> handler = property.getValue();
+        handler.handle(new ActionDataEvent(bean, 7, 13));
+    }
+    // END: com.dukescript.javafx.tests.BeanInfoCheck#invokeEventHandlerProperty
 }

--- a/beaninfo-testing/app/src/main/java/com/dukescript/javafx/tests/BeanInfoCheck.java
+++ b/beaninfo-testing/app/src/main/java/com/dukescript/javafx/tests/BeanInfoCheck.java
@@ -56,7 +56,7 @@ public class BeanInfoCheck {
     private static
     // BEGIN: com.dukescript.javafx.tests.BeanInfoCheck#CountingBean
     class CountingBean implements FXBeanInfo.Provider {
-        int count;
+        private int count;
 
         private void addAction(ActionEvent ev) {
             count += ((Number) ev.getSource()).intValue();

--- a/beaninfo-testing/browser/pom.xml
+++ b/beaninfo-testing/browser/pom.xml
@@ -11,10 +11,10 @@
   to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
   copies of the Software, and to permit persons to whom the Software is
   furnished to do so, subject to the following conditions:
-  
+
   The above copyright notice and this permission notice shall be included in
   all copies or substantial portions of the Software.
-  
+
   THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
   IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
   FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -86,5 +86,66 @@
             <scope>test</scope>
             <type>jar</type>
         </dependency>
+        <dependency>
+            <groupId>org.javafxports</groupId>
+            <artifactId>dalvik-sdk</artifactId>
+            <version>8.60.11</version>
+            <type>zip</type>
+        </dependency>
     </dependencies>
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <version>2.18.1</version>
+                <configuration>
+                    <junitArtifactName>com.dukescript.api:junit-osgi</junitArtifactName>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-dependency-plugin</artifactId>
+                <version>2.9</version>
+                <executions>
+                    <execution>
+                        <id>dalvik-sdk</id>
+                        <phase>validate</phase>
+                        <goals>
+                            <goal>unpack-dependencies</goal>
+                        </goals>
+                        <configuration>
+                            <includeArtifactIds>dalvik-sdk</includeArtifactIds>
+                            <includeScope>runtime</includeScope>
+                            <outputDirectory>${project.build.directory}/zips</outputDirectory>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-antrun-plugin</artifactId>
+                <version>1.8</version>
+                <executions>
+                    <execution>
+                        <id>dalvik-sdk</id>
+                        <phase>process-classes</phase>
+                        <configuration>
+                            <tasks>
+                                <unzip src="${basedir}/target/zips/dalvik-sdk/rt/lib/ext/jfxrt.jar" dest="${basedir}/target/classes/">
+                                    <patternset>
+                                        <include name="javafx/beans/**"/>
+                                        <include name="javafx/event/**"/>
+                                    </patternset>
+                                </unzip>
+                            </tasks>
+                        </configuration>
+                        <goals>
+                            <goal>run</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
 </project>

--- a/beaninfo-testing/browser/src/test/java/com/dukescript/javafx/browser/BeanInfoTest.java
+++ b/beaninfo-testing/browser/src/test/java/com/dukescript/javafx/browser/BeanInfoTest.java
@@ -36,6 +36,6 @@ import org.junit.runner.RunWith;
 public class BeanInfoTest extends BeanInfoCheck {
     @Test
     public void verifySimpleTest() {
-        assertEquals(Integer.valueOf("5"), new Integer(5));
+        assertEquals(Integer.valueOf("5"), Integer.valueOf(5));
     }
 }


### PR DESCRIPTION
Introducing `EventHandlerProperty` to make the generics signature less scary.